### PR TITLE
Propagate errors from neat_addr_update_src_list

### DIFF
--- a/neat_addr.c
+++ b/neat_addr.c
@@ -62,7 +62,7 @@ uint8_t neat_addr_cmp_ip6_addr(struct in6_addr *aAddr,
 }
 
 //Add/remove/update a source address based on information received from OS
-void neat_addr_update_src_list(struct neat_ctx *nc,
+neat_error_code neat_addr_update_src_list(struct neat_ctx *nc,
         struct sockaddr_storage *src_addr, uint32_t if_idx,
         uint8_t newaddr, uint8_t pref_length, uint32_t ifa_pref, uint32_t ifa_valid)
 {
@@ -120,7 +120,7 @@ void neat_addr_update_src_list(struct neat_ctx *nc,
             neat_run_event_cb(nc, NEAT_UPDATEADDR, nsrc_addr);
         }
 
-        return;
+        return NEAT_ERROR_OK;
     }
 
     //No match found, so create a new address, add it to list and announce it to
@@ -130,7 +130,7 @@ void neat_addr_update_src_list(struct neat_ctx *nc,
     if (nsrc_addr == NULL) {
         neat_log(NEAT_LOG_ERROR, "%s: Could not allocate memory for %s", __func__, addr_str);
         //TODO: Trigger a refresh of available addresses
-        return;
+        return NEAT_ERROR_OUT_OF_MEMORY;
     }
 
     nsrc_addr->family = src_addr->ss_family;
@@ -148,6 +148,7 @@ void neat_addr_update_src_list(struct neat_ctx *nc,
     ++nc->src_addr_cnt;
     neat_addr_print_src_addrs(nc);
     neat_run_event_cb(nc, NEAT_NEWADDR, nsrc_addr);
+    return NEAT_ERROR_OK;
 }
 
 void neat_addr_lifetime_timeout_cb(uv_timer_t *handle)

--- a/neat_addr.h
+++ b/neat_addr.h
@@ -42,7 +42,7 @@ struct neat_addr {
 };
 
 //Add/remove addresses from src. address list
-void neat_addr_update_src_list(struct neat_ctx *nc,
+neat_error_code neat_addr_update_src_list(struct neat_ctx *nc,
         struct sockaddr_storage *src_addr, uint32_t if_idx,
         uint8_t newaddr, uint8_t pref_length, uint32_t ifa_pref, uint32_t ifa_valid);
 

--- a/neat_bsd.c
+++ b/neat_bsd.c
@@ -33,7 +33,7 @@ neat_time(void)
 #endif
 }
 
-static void neat_bsd_get_addresses(struct neat_ctx *ctx)
+static neat_error_code neat_bsd_get_addresses(struct neat_ctx *ctx)
 {
     struct ifaddrs *ifp, *ifa;
     struct in6_ifreq ifr6;
@@ -43,11 +43,12 @@ static void neat_bsd_get_addresses(struct neat_ctx *ctx)
     time_t now;
     struct in6_addrlifetime *lifetime;
     uint32_t preferred_lifetime, valid_lifetime;
+    neat_error_code rc = NEAT_ERROR_OK;
 
     if (getifaddrs(&ifp) < 0) {
         neat_log(NEAT_LOG_ERROR,
                 "%s: getifaddrs() failed: %s", __func__, strerror(errno));
-        return;
+        return NEAT_ERROR_IO;
     }
     now = neat_time();
     cached_ifname = "";
@@ -117,15 +118,18 @@ static void neat_bsd_get_addresses(struct neat_ctx *ctx)
                 valid_lifetime = 0;
             }
         }
-        neat_addr_update_src_list(ctx,
-                                  (struct sockaddr_storage *)ifa->ifa_addr,
-                                  cached_ifindex,
-                                  1,
-                                  0,
-                                  preferred_lifetime,
-                                  valid_lifetime);
+        rc = neat_addr_update_src_list(ctx,
+                                       (struct sockaddr_storage *)ifa->ifa_addr,
+                                       cached_ifindex,
+                                       1,
+                                       0,
+                                       preferred_lifetime,
+                                       valid_lifetime);
+        if (rc)
+          break;
     }
     freeifaddrs(ifp);
+    return rc;
 }
 
 #define NEAT_ROUTE_BUFFER_SIZE 8192
@@ -169,11 +173,11 @@ static void neat_bsd_get_rtaddrs(int addrs,
     }
 }
 
-static void neat_bsd_route_recv(uv_udp_t *handle,
-                                ssize_t nread,
-                                const uv_buf_t *buf,
-                                const struct sockaddr *addr,
-                                unsigned int flags)
+static net_error_code neat_bsd_route_recv(uv_udp_t *handle,
+                                          ssize_t nread,
+                                          const uv_buf_t *buf,
+                                          const struct sockaddr *addr,
+                                          unsigned int flags)
 {
     struct neat_ctx *ctx;
     struct ifa_msghdr *ifa;
@@ -189,7 +193,7 @@ static void neat_bsd_route_recv(uv_udp_t *handle,
     ctx = (struct neat_ctx *)handle->data;
     ifa = (struct ifa_msghdr *)buf->base;
     if ((ifa->ifam_type != RTM_NEWADDR) && (ifa->ifam_type != RTM_DELADDR)) {
-        return;
+        return NEAT_ERROR_OK;
     }
     neat_bsd_get_rtaddrs(ifa->ifam_addrs, (caddr_t)(ifa + 1), rti_info);
     if ((rti_info[RTAX_IFA]->sa_family == AF_INET) ||
@@ -201,7 +205,7 @@ static void neat_bsd_route_recv(uv_udp_t *handle,
             neat_log(NEAT_LOG_ERROR,
                     "%s: can't determine name of interface with index %u",
                     __func__, ifa->ifam_index);
-            return;
+            return NEAT_ERROR_OK;
         }
         lifetime = &ifr6.ifr_ifru.ifru_lifetime;
         strncpy(ifr6.ifr_name, if_name, IF_NAMESIZE);
@@ -211,7 +215,7 @@ static void neat_bsd_route_recv(uv_udp_t *handle,
             neat_log(NEAT_LOG_ERROR,
                     "%s: can't determine lifetime of address %s (%s)",
                     __func__, addr_str ? addr_str : "Invalid IPv6 address", strerror(errno));
-            return;
+            return NEAT_ERROR_OK;
         }
         now = neat_time();
         if (lifetime->ia6t_preferred == 0) {
@@ -229,13 +233,14 @@ static void neat_bsd_route_recv(uv_udp_t *handle,
             valid_lifetime = 0;
         }
     }
-    neat_addr_update_src_list(ctx,
-                              (struct sockaddr_storage *)rti_info[RTAX_IFA],
-                              ifa->ifam_index,
-                              ifa->ifam_type == RTM_NEWADDR ? 1 : 0,
-                              0,
-                              preferred_lifetime,
-                              valid_lifetime);
+    return
+      neat_addr_update_src_list(ctx,
+                                (struct sockaddr_storage *)rti_info[RTAX_IFA],
+                                ifa->ifam_index,
+                                ifa->ifam_type == RTM_NEWADDR ? 1 : 0,
+                                0,
+                                preferred_lifetime,
+                                valid_lifetime);
 }
 
 static void neat_bsd_cleanup(struct neat_ctx *ctx)


### PR DESCRIPTION
Another small step at introducing error code use more widely and propagating *alloc() failures up the chain.
